### PR TITLE
Enable protect_from_forgery, with failing test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,8 +25,8 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  # Enable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory
   config.active_storage.service = :test

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -25,6 +25,23 @@ class WelcomeControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to signed_in_url
   end
 
+  test "signing in with a POST (not using Devise helper)" do
+    user = users(:one)
+    get '/users/sign_in'
+    csrf_token = form_authenticity_token(response.body)
+
+    post '/users/sign_in', params: {
+      authenticity_token: csrf_token,
+      user: { email: user.email, password: 'testpass' }
+    }
+
+    assert_response :redirect
+    assert_redirected_to root_url
+
+    assert_response :redirect
+    assert_redirected_to signed_in_url
+  end
+
   test "with a signed in user the signed in page loads" do
     user = users(:one)
     sign_in user

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,6 +6,7 @@
 #
 one:
   email: test@example.com
+  encrypted_password: <%= User.new.send(:password_digest, 'testpass') %>
 
 two:
   email: test2@example.com

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,11 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  def form_authenticity_token(body)
+    regex = /type="hidden" name="authenticity_token" value="(?<token>.+)"/
+    parts = response.body.match(regex)
+    parts['token'] if parts
+  end
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
Not intended to be merged... demonstrates an issue (described here https://github.com/twilio/authy-devise/issues/109): enabling CSRF protection with the `authy-devise` Gem is resulting in an `ActionController::InvalidAuthenticityToken` error when logging in.

Removing the gem/config from the app makes this test work