### PR TITLE
Support .env solution for Authy Devise Demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+AUTHY_API_KEY="place api key here"

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@
 /public/assets
 .byebug_history
 
+.env
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'dotenv-rails'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/README.md
+++ b/README.md
@@ -22,9 +22,19 @@ rails db:create db:migrate
 
 Get your Authy application API key from the [Twilio console](https://www.twilio.com/console/authy/applications) and set it in your environment variables:
 
+Through CLI:
+
 ```bash
 export AUTHY_API_KEY=YOUR_API_KEY
 ```
+
+Or in .env:
+
+```bash
+cp .env{.example,}
+```
+
+Place API key in .env file generated from above command.
 
 Run the Rails application:
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->
I added the `dot-env` Gem, and an example `.env` file to closer mirror a traditional Rails solution.
I also updated the ReadMe to reflect these changes. My formatter caught some indentation misalignments in the ReadMe as well.

Some rack solutions (like Unicorn) have issues with the CLI exporting of ENV variables
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
